### PR TITLE
Fix check for existing flutter submodule

### DIFF
--- a/flutterw
+++ b/flutterw
@@ -44,7 +44,7 @@ if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
 fi
 
 # submodule starting with "-" are not initialized
-init_status=`git submodule | grep .flutter | cut -c 1`
+init_status=`git submodule | fgrep .flutter | cut -c 1`
 
 # Fix not initialized flutter submodule
 if [ "$init_status" = "-" ]; then

--- a/flutterw
+++ b/flutterw
@@ -44,7 +44,7 @@ if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
 fi
 
 # submodule starting with "-" are not initialized
-init_status=`git submodule | fgrep .flutter | cut -c 1`
+init_status=`git submodule | git submodule | grep "\ \.flutter\ " | cut -c 1`
 
 # Fix not initialized flutter submodule
 if [ "$init_status" = "-" ]; then

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ printf "Installing Flutter Wrapper $VERSION_TAG\n"
 FLUTTER_DIR_NAME='.flutter'
 
 # Check if submodule already exists (when updating flutter wrapper)
-HAS_SUBMODULE=`git submodule | fgrep .flutter`
+HAS_SUBMODULE=`git submodule | grep "\ \.flutter\ "`
 if [ -z "$HAS_SUBMODULE" ]; then
   printf "adding '.flutter' submodule\n"
   UPDATED=false

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ printf "Installing Flutter Wrapper $VERSION_TAG\n"
 FLUTTER_DIR_NAME='.flutter'
 
 # Check if submodule already exists (when updating flutter wrapper)
-HAS_SUBMODULE=`git submodule | grep .flutter`
+HAS_SUBMODULE=`git submodule | fgrep .flutter`
 if [ -z "$HAS_SUBMODULE" ]; then
   printf "adding '.flutter' submodule\n"
   UPDATED=false


### PR DESCRIPTION
In my project I have a submodule named `flutter_custom_tabs`, which breaks the wrapper's check for the existing flutter submodule. This change [references](https://stackoverflow.com/a/10346824/3911006) the fact that the `.flutter` command in grep is using regex, meaning anyone else with submodules that match with the string `flutter` in it will fail silently here.