### PR TITLE
Not stage `flutter channel`

### DIFF
--- a/flutterw
+++ b/flutterw
@@ -85,7 +85,7 @@ FLUTTER_EXIT_STATUS=$?
 if [ ${FLUTTER_EXIT_STATUS} -eq 0 ]; then
 
   # ./flutterw channel CHANNEL
-  if echo "$@" | grep -q "channel"; then
+  if [ echo "$@" | grep -q "channel" ] && [ ! -z "$2" ]; then
     # make sure .gitmodules is updated as well
     CHANNEL=${2} # second arg
     git config -f "${GIT_HOME}/.gitmodules" "submodule.${FLUTTER_SUBMODULE_NAME}.branch" "${CHANNEL}"

--- a/test/flutterw
+++ b/test/flutterw
@@ -87,7 +87,7 @@ FLUTTER_EXIT_STATUS=$?
 if [ ${FLUTTER_EXIT_STATUS} -eq 0 ]; then
 
   # ./flutterw channel CHANNEL
-  if echo "$@" | grep -q "channel"; then
+  if [ echo "$@" | grep -q "channel" ] && [ ! -z "$2" ]; then
     # make sure .gitmodules is updated as well
     CHANNEL=${2} # second arg
     git config -f .gitmodules submodule.${FLUTTER_SUBMODULE_NAME}.branch ${CHANNEL}

--- a/test/test/submodule_test.dart
+++ b/test/test/submodule_test.dart
@@ -92,7 +92,7 @@ void main() {
     );
 
     test(
-      'flutter channel without second arg called from package updates gitmodules in root',
+      'flutter channel without second arg called from package does not update gitmodules in root',
       () async {
         final repo = const LocalFileSystem().systemTempDirectory.createTempSync('repo');
         addTearDown(() {

--- a/test/test/submodule_test.dart
+++ b/test/test/submodule_test.dart
@@ -50,6 +50,24 @@ void main() {
     );
 
     test(
+      'flutter channel without second arg does not update gitmodules (single module)',
+      () async {
+        final repo = const LocalFileSystem().systemTempDirectory.createTempSync('repo');
+        addTearDown(() {
+          repo.deleteSync(recursive: true);
+        });
+        await run('git init -b master', workingDirectory: repo.absolute.path);
+        await runInstallScript(workingDirectory: repo.absolute.path);
+        await run('git commit -a -m "initial commit"', workingDirectory: repo.absolute.path);
+        expect(repo.childFile('.gitmodules').readAsStringSync(), contains('branch = stable'));
+
+        await run('./flutterw channel', workingDirectory: repo.absolute.path);
+        expect(repo.childFile('.gitmodules').readAsStringSync(), contains('branch = stable'));
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+    );
+
+    test(
       'flutter channel <X> called from package updates gitmodules in root',
       () async {
         final repo = const LocalFileSystem().systemTempDirectory.createTempSync('repo');
@@ -69,6 +87,30 @@ void main() {
         expect(package.childFile('.gitmodules').existsSync(), isFalse);
         // updates .gitmodules in root
         expect(repo.childFile('.gitmodules').readAsStringSync(), contains('branch = beta'));
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+    );
+
+    test(
+      'flutter channel without second arg called from package updates gitmodules in root',
+      () async {
+        final repo = const LocalFileSystem().systemTempDirectory.createTempSync('repo');
+        addTearDown(() {
+          repo.deleteSync(recursive: true);
+        });
+        await run('git init -b master', workingDirectory: repo.absolute.path);
+        await runInstallScript(workingDirectory: repo.absolute.path);
+        await run('git commit -a -m "initial commit"', workingDirectory: repo.absolute.path);
+        expect(repo.childFile('.gitmodules').readAsStringSync(), contains('branch = stable'));
+
+        // create package
+        final package = repo.childDirectory('packages/xyz')..createSync(recursive: true);
+
+        await run('./../../flutterw channel', workingDirectory: package.absolute.path);
+        // doesn't accidentally create a .gitmodules file in package
+        expect(package.childFile('.gitmodules').existsSync(), isFalse);
+        // Doesn't update .gitmodules in root
+        expect(repo.childFile('.gitmodules').readAsStringSync(), contains('branch = stable'));
       },
       timeout: const Timeout(Duration(minutes: 5)),
     );


### PR DESCRIPTION
If currently `flutter channel` is entered, the channel is switched to an empty channel, which ideally should not be the case.

The behavior is changed so that it only happens when a second argument was entered.