### PR TITLE
Check flutter version is specified in pubspec.yaml

### DIFF
--- a/flutterw
+++ b/flutterw
@@ -53,23 +53,24 @@ fi
 
 # Ensure flutter version matches pubspec.yaml file
 PUBSPEC_VERSION=$(yq eval '.environment.flutter' pubspec.yaml)
-if [ -z "$PUBSPEC_VERSION" ]; then
-  echoerr "Warning: yq is not installed so could not verify that the .flutter version matches the "\
+if [ -z "${PUBSPEC_VERSION}" ]; then
+  echoerr "Warning: yq is not installed so could not verify that the .flutter version matches the"\
     "value in pubspec.yaml"
-  echoerr "Install using \`brew install yq\` or \`snap install yq\` to silence this warning"
-elif [ "$PUBSPEC_VERSION" = "null" ]; then
+  echoerr "Install using \`brew install yq\` or \`snap install yq\` depending on your platform to"\
+    "silence this warning"
+elif [ "${PUBSPEC_VERSION}" = "null" ]; then
   echoerr "Warning: Flutter version was not specified in pubspec.yaml.  Adding it for you now..."
   FLUTTER_VERSION=$(cd .flutter && git describe --tags --exact-match)
-  yq -i ".environment.flutter = \"$FLUTTER_VERSION\"" pubspec.yaml
-  echoerr "Flutter version set to $FLUTTER_VERSION in pubspec.yaml"
+  yq -i ".environment.flutter = \"${FLUTTER_VERSION}\"" pubspec.yaml
+  echoerr "Flutter version set to ${FLUTTER_VERSION} in pubspec.yaml"
   unset FLUTTER_VERSION
 else
-  PUBSPEC_COMMIT=$(cd .flutter && (git rev-parse "$PUBSPEC_VERSION" 2> /dev/null) || (git fetch && git rev-parse "$PUBSPEC_VERSION"))
+  PUBSPEC_COMMIT=$(cd .flutter && (git rev-parse "${PUBSPEC_VERSION}" 2> /dev/null) || (git fetch && git rev-parse "${PUBSPEC_VERSION}"))
   CURRENT_COMMIT=$(cd .flutter && git rev-parse HEAD)
 
-  if [ "$CURRENT_COMMIT" != "$PUBSPEC_COMMIT" ]; then
-    echoerr "Updating flutter version to match $PUBSPEC_VERSION specified in pubspec.yaml"
-    (cd .flutter && git checkout --quiet "$PUBSPEC_COMMIT" && rm -rf .flutter/bin/cache)
+  if [ "${CURRENT_COMMIT}" != "${PUBSPEC_COMMIT}" ]; then
+    echoerr "Updating flutter version to match ${PUBSPEC_VERSION} specified in pubspec.yaml"
+    (cd .flutter && git fetch --all --tags --quiet && git checkout --quiet "tags/${PUBSPEC_COMMIT}" && rm -rf .flutter/bin/cache)
   fi
 fi
 

--- a/flutterw
+++ b/flutterw
@@ -54,23 +54,23 @@ fi
 # Ensure flutter version matches pubspec.yaml file
 PUBSPEC_VERSION=$(yq eval '.environment.flutter' pubspec.yaml)
 if [ -z "${PUBSPEC_VERSION}" ]; then
-  echoerr "Warning: yq is not installed so could not verify that the .flutter version matches the"\
-    "value in pubspec.yaml"
-  echoerr "Install using \`brew install yq\` or \`snap install yq\` depending on your platform to"\
+  echoerr "Warning: yq is not installed so could not verify that the ${FLUTTER_SUBMODULE_NAME}" \
+    "Flutter version matches the value in pubspec.yaml"
+  echoerr "Install using \`brew install yq\` or \`snap install yq\` depending on your platform to" \
     "silence this warning"
 elif [ "${PUBSPEC_VERSION}" = "null" ]; then
   echoerr "Warning: Flutter version was not specified in pubspec.yaml.  Adding it for you now..."
-  FLUTTER_VERSION=$(cd .flutter && git describe --tags --exact-match)
+  FLUTTER_VERSION=$(cd "${FLUTTER_DIR}" && git describe --tags --exact-match)
   yq -i ".environment.flutter = \"${FLUTTER_VERSION}\"" pubspec.yaml
   echoerr "Flutter version set to ${FLUTTER_VERSION} in pubspec.yaml"
   unset FLUTTER_VERSION
 else
-  PUBSPEC_COMMIT=$(cd .flutter && (git rev-parse "${PUBSPEC_VERSION}" 2> /dev/null) || (git fetch && git rev-parse "${PUBSPEC_VERSION}"))
-  CURRENT_COMMIT=$(cd .flutter && git rev-parse HEAD)
+  PUBSPEC_COMMIT=$(cd "${FLUTTER_DIR}" && git fetch --all --tags --quiet && git rev-parse "tags/${PUBSPEC_VERSION}")
+  CURRENT_COMMIT=$(cd "${FLUTTER_DIR}" && git rev-parse HEAD)
 
   if [ "${CURRENT_COMMIT}" != "${PUBSPEC_COMMIT}" ]; then
     echoerr "Updating flutter version to match ${PUBSPEC_VERSION} specified in pubspec.yaml"
-    (cd .flutter && git fetch --all --tags --quiet && git checkout --quiet "tags/${PUBSPEC_COMMIT}" && rm -rf .flutter/bin/cache)
+    (cd "${FLUTTER_DIR}" && git checkout --quiet "${PUBSPEC_COMMIT}" && rm -rf "${FLUTTER_DIR}/bin/cache")
   fi
 fi
 

--- a/flutterw
+++ b/flutterw
@@ -51,6 +51,28 @@ if [ ! -f "${FLUTTER_DIR}/bin/flutter" ]; then
   git submodule update --init "${FLUTTER_DIR}"
 fi
 
+# Ensure flutter version matches pubspec.yaml file
+PUBSPEC_VERSION=$(yq eval '.environment.flutter' pubspec.yaml)
+if [ -z "$PUBSPEC_VERSION" ]; then
+  echoerr "Warning: yq is not installed so could not verify that the .flutter version matches the "\
+    "value in pubspec.yaml"
+  echoerr "Install using \`brew install yq\` or \`snap install yq\` to silence this warning"
+elif [ "$PUBSPEC_VERSION" = "null" ]; then
+  echoerr "Warning: Flutter version was not specified in pubspec.yaml.  Adding it for you now..."
+  FLUTTER_VERSION=$(cd .flutter && git describe --tags --exact-match)
+  yq -i ".environment.flutter = \"$FLUTTER_VERSION\"" pubspec.yaml
+  echoerr "Flutter version set to $FLUTTER_VERSION in pubspec.yaml"
+  unset FLUTTER_VERSION
+else
+  PUBSPEC_COMMIT=$(cd .flutter && (git rev-parse "$PUBSPEC_VERSION" 2> /dev/null) || (git fetch && git rev-parse "$PUBSPEC_VERSION"))
+  CURRENT_COMMIT=$(cd .flutter && git rev-parse HEAD)
+
+  if [ "$CURRENT_COMMIT" != "$PUBSPEC_COMMIT" ]; then
+    echoerr "Updating flutter version to match $PUBSPEC_VERSION specified in pubspec.yaml"
+    (cd .flutter && git checkout --quiet "$PUBSPEC_COMMIT" && rm -rf .flutter/bin/cache)
+  fi
+fi
+
 # Detect detach HEAD and fix it. commands like upgrade expect a valid branch, not a detached HEAD
 FLUTTER_SYMBOLIC_REF=$(git -C "${FLUTTER_DIR}" symbolic-ref -q HEAD)
 if [ -z "${FLUTTER_SYMBOLIC_REF}" ]; then


### PR DESCRIPTION
Building on the contribution from @fdietze in #23, this PR keeps the submodule version in sync with the flutter version in the environment.flutter variable in pubspec.yaml.

This functionality depends on `yq` but emits a warning and continues gracefully if it isn't.

Fixes #23 